### PR TITLE
Add dialog keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ A simple, promise-based approach to managing Dialogs in React.
 * [Installation](#installation)
 * [Quick Start](#quick-start)
 * [Usage with Typescript](#typescript)
+* [Optimization](#optimization)
 * [Examples](https://github.com/alexn400/react-dialog-async/tree/main/examples)
 
 # Installation
@@ -124,3 +125,20 @@ const App = () => {
 # Contributing
 Contributions are more than welcome!
 If you have a use-case that the library currently doesn't support please raise it in an issue or pull request 😄
+
+# Optimization
+If you're using the same dialog across multiple components, you can optimize performance by assigning a `dialogKey` to your dialog component:
+```js
+const QuestionDialog = ({ open }) => {
+  if (!open) return null;
+
+  return (
+    <div className={'dialog'}>
+      ...
+    </div>
+  )
+};
+
+QuestionDialog.dialogKey = "QuestionDialog";
+```
+This allows the DialogProvider to reuse the same instance of the dialog, instead of maintaining separate instances of the dialog for each `useDialog()` hook

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-dialog-async",
   "description": "A promise-based way to show dialogs in React",
-  "version": "1.2.1",
+  "version": "1.3.1",
   "main": "dist/index.js",
   "module": "dist/index.esm.js",
   "types": "dist/index.d.ts",

--- a/src/DialogProvider/DialogProvider.test.tsx
+++ b/src/DialogProvider/DialogProvider.test.tsx
@@ -3,8 +3,19 @@ import { render, screen } from '@testing-library/react';
 import DialogProvider from './DialogProvider';
 import { useContext, useEffect } from 'react';
 import DialogContext from '../DialogContext';
+import { AsyncDialogProps } from '../types';
 
-const TestDialog = () => <div>{'Hello World!'}</div>;
+const TestDialog = ({ open }: AsyncDialogProps) => {
+  if (!open) return null;
+
+  return <div>{'Hello World!'}</div>;
+};
+const TestDialogWithKey = ({ open }: AsyncDialogProps) => {
+  if (!open) return null;
+
+  return <div>{'Hello World!'}</div>;
+};
+TestDialogWithKey.dialogKey = 'test-dialog';
 
 // const TestDialogWithData = ({ data }: AsyncDialogProps<any, any>) => (
 //   <div>Hello World!</div>
@@ -61,4 +72,76 @@ test('calling register() followed by show() mounts the dialog in the DOM', () =>
 
   expect(result.asFragment()).toMatchSnapshot();
   expect(screen.getByText('Hello World!')).toBeDefined();
+});
+
+test('calling register() followed by show() followed by hide() unmounts the dialog in the DOM', () => {
+  const InnerComponent = () => {
+    const ctx = useContext(DialogContext);
+
+    useEffect(() => {
+      const id = ctx.register(TestDialog);
+
+      ctx.show(id, {});
+
+      ctx.hide(id);
+    }, []);
+
+    return null;
+  };
+  const result = render(
+    <DialogProvider>
+      <InnerComponent />
+    </DialogProvider>,
+  );
+
+  expect(result.asFragment()).toMatchSnapshot();
+  expect(screen.queryByText('Hello World!')).toBeNull();
+});
+
+test('calling register() twice on a dialog with no key results in two dialogs being mounted', () => {
+  const InnerComponent = () => {
+    const ctx = useContext(DialogContext);
+
+    useEffect(() => {
+      const id1 = ctx.register(TestDialog);
+      const id2 = ctx.register(TestDialog);
+
+      ctx.show(id1, {});
+      ctx.show(id2, {});
+    }, []);
+
+    return null;
+  };
+  const result = render(
+    <DialogProvider>
+      <InnerComponent />
+    </DialogProvider>,
+  );
+
+  expect(result.asFragment()).toMatchSnapshot();
+  expect(screen.getAllByText('Hello World!')).toHaveLength(2);
+});
+
+test('calling register() twice on a dialog a key results in only 1 dialog being mounted', () => {
+  const InnerComponent = () => {
+    const ctx = useContext(DialogContext);
+
+    useEffect(() => {
+      const id1 = ctx.register(TestDialogWithKey);
+      const id2 = ctx.register(TestDialogWithKey);
+
+      ctx.show(id1, {});
+      ctx.show(id2, {});
+    }, []);
+
+    return null;
+  };
+  const result = render(
+    <DialogProvider>
+      <InnerComponent />
+    </DialogProvider>,
+  );
+
+  expect(result.asFragment()).toMatchSnapshot();
+  expect(screen.getAllByText('Hello World!')).toHaveLength(1);
 });

--- a/src/DialogProvider/__snapshots__/DialogProvider.test.tsx.snap
+++ b/src/DialogProvider/__snapshots__/DialogProvider.test.tsx.snap
@@ -2,8 +2,29 @@
 
 exports[`calling register() does not mount the dialog 1`] = `<DocumentFragment />`;
 
+exports[`calling register() followed by show() followed by hide() unmounts the dialog in the DOM 1`] = `<DocumentFragment />`;
+
 exports[`calling register() followed by show() mounts the dialog in the DOM 1`] = `
 <DocumentFragment>
+  <div>
+    Hello World!
+  </div>
+</DocumentFragment>
+`;
+
+exports[`calling register() twice on a dialog a key results in only 1 dialog being mounted 1`] = `
+<DocumentFragment>
+  <div>
+    Hello World!
+  </div>
+</DocumentFragment>
+`;
+
+exports[`calling register() twice on a dialog with no key results in two dialogs being mounted 1`] = `
+<DocumentFragment>
+  <div>
+    Hello World!
+  </div>
   <div>
     Hello World!
   </div>

--- a/src/types.ts
+++ b/src/types.ts
@@ -9,7 +9,7 @@ export interface AsyncDialogProps<Request = void, Response = undefined> {
 /**
  * Represents a dialog component that can be used with `useDialog`
  */
-export type DialogComponent<D, R> = ComponentType<AsyncDialogProps<D, R>>;
+export type DialogComponent<D, R> = ComponentType<AsyncDialogProps<D, R>> & { dialogKey?: string };
 
 /**
  * Used internally to store all info relating to a single dialog


### PR DESCRIPTION
Adds a `dialogKey` option to dialog components. This allows you to optimise cases where multiple of the same dialog is registered. 
>This behaviour is **opt-in**, dialogs without a defined `dialogKey` will behave exactly as they did before

Usage:
```ts
const MyDialog = ({ open }: AsyncDialogProps) => {
  return <Modal open={open}>...</Modal>
}

MyDialog.dialogKey = 'unique-key-goes-here'
```

This optimises the following case:

```ts
// Component A
...
const dialog = useDialog(MyDialog);

// Component B
...
const dialog = useDialog(MyDialog);
```
Previously, this would have caused both dialogs to be treated separately

Two different dialogs with the same dialog key results in undefined behaviour and should be avoided