### PR TITLE
New `DialogOptions` for `useDialog()`

### DIFF
--- a/docs/docs/API/dialog-provider.md
+++ b/docs/docs/API/dialog-provider.md
@@ -15,12 +15,5 @@ Provides a react context for rendering dialogs. The dialogs themselves will also
 </DialogProvider>
 ```
 
-## Props
-
-| Name       | Type              | Default value | Description |
-|------------|-------------------|---------------|-------------|
-| `children` | `React.ReactNode` |               |             |
-
-## Source
 ## Source
 [Source for `DialogProvider` on GitHub](https://github.com/a16n-dev/react-dialog-async/blob/main/src/DialogProvider/DialogProvider.tsx)

--- a/docs/docs/API/use-dialog.md
+++ b/docs/docs/API/use-dialog.md
@@ -17,5 +17,22 @@ const onClick = async () => {
 }
 ```
 
+## Dialog Options
+_Available from v2.1.0_
+
+`useDialog` also optionally takes in a second argument for dialog options
+```useDialogOptions```
+```tsx
+const myDialog = useDialog(MyDialog, {
+  // Pass options here
+});
+```
+
+Available options are:
+
+* `defaultData` - Default data to pass to the dialog component. Specifying this makes passing data to `.show()` optional, but data passed to `.show()` will still override the default data.
+* `dialogKey` - 
+
+
 ## Source
 [Source for `useDialog` on GitHub](https://github.com/a16n-dev/react-dialog-async/blob/main/src/useDialog.ts)

--- a/docs/docs/API/use-dialog.md
+++ b/docs/docs/API/use-dialog.md
@@ -31,8 +31,15 @@ const myDialog = useDialog(MyDialog, {
 Available options are:
 
 * `defaultData` - Default data to pass to the dialog component. Specifying this makes passing data to `.show()` optional, but data passed to `.show()` will still override the default data.
-* `dialogKey` - 
+* `customKey` - By default, only one instance of a dialog component is stored internally, regardless of how many places it is used with `useDialog`. If this behaviour is not desired, a `customKey` can be specified to create a new instance of the dialog component.
 
+## Return Type
+The object returned by `useDialog` has the following properties:
+* `show` - A function that shows the dialog. It takes in data to make available to the dialog component, and returns a promise that resolves to data returned by the dialog
+* `hide` - A function for manually closing the dialog. You don't need to call this unless you need to forcefully close the dialog
+* `updateData` - A function for updating the data available to the dialog. This can be useful if you need to update the data after the dialog has been opened
+* `open` - Alias for `show`
+* `close` - Alias for `hide`
 
 ## Source
 [Source for `useDialog` on GitHub](https://github.com/a16n-dev/react-dialog-async/blob/main/src/useDialog.ts)

--- a/docs/docs/resources/faq.md
+++ b/docs/docs/resources/faq.md
@@ -14,3 +14,5 @@ return (
 )
 ```
 
+## Q: Does react-dialog-async use `createPortal`?
+No, react-dialog-async renders dialogs directly as children of the `DialogProvider`. This is because most UI libraries already handle portal behaviour, so doing it again would be redundant.

--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -38,7 +38,8 @@ const config: Config = {
         docs: {
           routeBasePath: '/',
           sidebarPath: './sidebars.ts',
-          editUrl: 'https://github.com/a16n-dev/react-dialog-async/tree/main/',
+          editUrl:
+            'https://github.com/a16n-dev/react-dialog-async/tree/main/docs',
         },
         blog: {
           showReadingTime: true,

--- a/packages/react-dialog-async/src/DialogProvider/DialogProvider.tsx
+++ b/packages/react-dialog-async/src/DialogProvider/DialogProvider.tsx
@@ -11,8 +11,8 @@ const DialogProvider = ({ children }: DialogProviderProps) => {
   const [dialogs, setDialogs] = useState<{
     dialogs: Record<string, DialogComponent<unknown, unknown>>;
     lookup: Record<string, string>;
-    idsList: Record<string, string[]>;
-  }>({ dialogs: {}, lookup: {}, idsList: {} });
+    idsCount: Record<string, number>;
+  }>({ dialogs: {}, lookup: {}, idsCount: {} });
 
   const [dialogState, setDialogState] = useState<
     Record<
@@ -42,30 +42,30 @@ const DialogProvider = ({ children }: DialogProviderProps) => {
       setDialogs((dialogs) => ({
         dialogs: { ...dialogs.dialogs, [key]: Component },
         lookup: { ...dialogs.lookup, [id]: key },
-        idsList: {
-          ...dialogs.idsList,
-          [key]: [...(dialogs.idsList[key] || []), id],
+        idsCount: {
+          ...dialogs.idsCount,
+          [key]: (dialogs.idsCount[key] || 0) + 1,
         },
       }));
 
       return () => {
         setDialogs((dialogs) => {
-          const newIds = dialogs.idsList[key].filter((i) => i !== id);
+          const newCount = dialogs.idsCount[key] - 1;
 
-          if (newIds.length === 0) {
+          if (newCount === 0) {
             return {
               dialogs: removeKey(dialogs.dialogs, key),
               lookup: removeKey(dialogs.lookup, id),
-              idsList: removeKey(dialogs.idsList, key),
+              idsCount: removeKey(dialogs.idsCount, key),
             };
           }
 
           return {
             dialogs: dialogs.dialogs,
             lookup: removeKey(dialogs.lookup, id),
-            idsList: {
-              ...dialogs.idsList,
-              [key]: newIds,
+            idsCount: {
+              ...dialogs.idsCount,
+              [key]: newCount,
             },
           };
         });

--- a/packages/react-dialog-async/src/types.ts
+++ b/packages/react-dialog-async/src/types.ts
@@ -15,7 +15,7 @@ export type DialogComponent<D, R> = ComponentType<AsyncDialogProps<D, R>>;
  * Used internally to store all info relating to a single dialog
  */
 
-export type useDialogReturn<D, R> = {
+export type useDialogReturn<D, R, DE extends D | undefined> = {
   /**
    * Shows the dialog, and passes the provided data as props to the dialog
    * component. Returns a promise that resolves when the dialog is closed.
@@ -23,7 +23,9 @@ export type useDialogReturn<D, R> = {
    * The resolved value is the value passed to `handleClose` in the dialog
    * component.
    */
-  show: (data: D) => Promise<R | undefined>;
+  show: DE extends undefined
+    ? (data: D) => Promise<R | undefined>
+    : (data?: D) => Promise<R | undefined>;
   /**
    * Hides the dialog
    */
@@ -36,9 +38,36 @@ export type useDialogReturn<D, R> = {
   /**
    * Alias for `show`
    */
-  open: (data: D) => Promise<R | undefined>;
+  open: DE extends undefined
+    ? (data: D) => Promise<R | undefined>
+    : () => Promise<R | undefined>;
   /**
    * Alias for `hide`
    */
   close: () => void;
 };
+
+export type useDialogOptions<
+  D,
+  DE extends D | undefined,
+  M extends boolean = false,
+> = {
+  /**
+   * Default data to pass to the dialog when .show() is called
+   */
+  defaultData?: DE;
+  /**
+   * By default, only open dialogs will be rendered. Set this to true if you
+   * want react-dialog-async to always render the dialog
+   */
+  keepMounted?: boolean;
+} & (
+  | {
+      defaultData: DE;
+      keepMounted: M extends true ? M : never;
+    }
+  | {
+      defaultData?: DE;
+      keepMounted?: M extends false ? M : never;
+    }
+);

--- a/packages/react-dialog-async/src/types.ts
+++ b/packages/react-dialog-async/src/types.ts
@@ -52,4 +52,8 @@ export type useDialogOptions<D, DE extends D | undefined> = {
    * Default data to pass to the dialog when .show() is called
    */
   defaultData?: DE;
+  /**
+   * A custom key to register this dialog against
+   */
+  customKey?: string;
 };

--- a/packages/react-dialog-async/src/types.ts
+++ b/packages/react-dialog-async/src/types.ts
@@ -47,27 +47,9 @@ export type useDialogReturn<D, R, DE extends D | undefined> = {
   close: () => void;
 };
 
-export type useDialogOptions<
-  D,
-  DE extends D | undefined,
-  M extends boolean = false,
-> = {
+export type useDialogOptions<D, DE extends D | undefined> = {
   /**
    * Default data to pass to the dialog when .show() is called
    */
   defaultData?: DE;
-  /**
-   * By default, only open dialogs will be rendered. Set this to true if you
-   * want react-dialog-async to always render the dialog
-   */
-  keepMounted?: boolean;
-} & (
-  | {
-      defaultData: DE;
-      keepMounted: M extends true ? M : never;
-    }
-  | {
-      defaultData?: DE;
-      keepMounted?: M extends false ? M : never;
-    }
-);
+};

--- a/packages/react-dialog-async/src/useDialog.test.tsx
+++ b/packages/react-dialog-async/src/useDialog.test.tsx
@@ -1,12 +1,16 @@
 import React from 'react';
 import { expect, test } from 'vitest';
-import { render } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import DialogProvider from './DialogProvider/DialogProvider';
 
 import useDialog from './useDialog';
-import { hashComponent } from './utils';
+import { AsyncDialogProps } from './types';
+import { useEffect } from 'react';
 
 const TestDialog = () => <div>Hello World!</div>;
+const TestDialogWithData = ({ data }: AsyncDialogProps<string>) => (
+  <div>{data}</div>
+);
 
 test('can be called without error', () => {
   const TestComponent = () => {
@@ -23,4 +27,69 @@ test('can be called without error', () => {
   expect(result.asFragment()).toMatchSnapshot();
 });
 
-console.log(hashComponent(TestDialog));
+test('data is used when default data is not provided', () => {
+  const message = Date.now().toString(16);
+  const TestComponent = () => {
+    const testDialog = useDialog(TestDialogWithData);
+
+    useEffect(() => {
+      testDialog.show(message);
+    }, []);
+
+    return null;
+  };
+
+  render(
+    <DialogProvider>
+      <TestComponent />
+    </DialogProvider>,
+  );
+
+  expect(screen.getByText(message)).toBeDefined();
+});
+
+test('default data is used when data is not provided', () => {
+  const message = Date.now().toString(16);
+  const TestComponent = () => {
+    const testDialog = useDialog(TestDialogWithData, {
+      defaultData: message,
+    });
+
+    useEffect(() => {
+      testDialog.show();
+    }, []);
+
+    return null;
+  };
+
+  render(
+    <DialogProvider>
+      <TestComponent />
+    </DialogProvider>,
+  );
+
+  expect(screen.getByText(message)).toBeDefined();
+});
+
+test('default data is overridden when data is provided', () => {
+  const message = Date.now().toString(16);
+  const TestComponent = () => {
+    const testDialog = useDialog(TestDialogWithData, {
+      defaultData: message,
+    });
+
+    useEffect(() => {
+      testDialog.show('Hello World!');
+    }, []);
+
+    return null;
+  };
+
+  render(
+    <DialogProvider>
+      <TestComponent />
+    </DialogProvider>,
+  );
+
+  expect(screen.queryByText(message)).toBeNull();
+});

--- a/packages/react-dialog-async/src/useDialog.ts
+++ b/packages/react-dialog-async/src/useDialog.ts
@@ -9,7 +9,10 @@ function useDialog<D, R, DE extends D | undefined>(
 ): useDialogReturn<D, R, DE> {
   const id = useId();
 
-  const key = useMemo(() => hashComponent(component), [component]);
+  const key = useMemo(
+    () => options?.customKey ?? hashComponent(component),
+    [component, options?.customKey],
+  );
 
   const ctx = useContext(DialogContext);
 

--- a/packages/react-dialog-async/src/useDialog.ts
+++ b/packages/react-dialog-async/src/useDialog.ts
@@ -1,11 +1,12 @@
 import { useContext, useEffect, useId, useMemo } from 'react';
 import DialogContext from './DialogContext';
-import { DialogComponent, useDialogReturn } from './types';
 import { hashComponent } from './utils';
+import { DialogComponent, useDialogOptions, useDialogReturn } from './types';
 
-const useDialog = <D, R>(
+function useDialog<D, R, DE extends D | undefined, M extends boolean = false>(
   component: DialogComponent<D, R>,
-): useDialogReturn<D, R> => {
+  options: useDialogOptions<D, DE, M> = {},
+): useDialogReturn<D, R, DE> {
   const id = useId();
 
   const key = useMemo(() => hashComponent(component), [component]);
@@ -19,8 +20,8 @@ const useDialog = <D, R>(
     };
   }, [id]);
 
-  const show = async (data: D): Promise<R | undefined> => {
-    return ctx.show(id, data);
+  const show = async (data?: D): Promise<R | undefined> => {
+    return ctx.show(id, data || options.defaultData);
   };
 
   const hide = () => {
@@ -38,6 +39,6 @@ const useDialog = <D, R>(
     open: show,
     close: hide,
   };
-};
+}
 
 export default useDialog;

--- a/packages/react-dialog-async/src/useDialog.ts
+++ b/packages/react-dialog-async/src/useDialog.ts
@@ -21,7 +21,7 @@ function useDialog<D, R, DE extends D | undefined, M extends boolean = false>(
   }, [id]);
 
   const show = async (data?: D): Promise<R | undefined> => {
-    return ctx.show(id, data || options.defaultData);
+    return ctx.show(id, data ?? options.defaultData);
   };
 
   const hide = () => {

--- a/packages/react-dialog-async/src/useDialog.ts
+++ b/packages/react-dialog-async/src/useDialog.ts
@@ -3,9 +3,9 @@ import DialogContext from './DialogContext';
 import { hashComponent } from './utils';
 import { DialogComponent, useDialogOptions, useDialogReturn } from './types';
 
-function useDialog<D, R, DE extends D | undefined, M extends boolean = false>(
+function useDialog<D, R, DE extends D | undefined>(
   component: DialogComponent<D, R>,
-  options: useDialogOptions<D, DE, M> = {},
+  options: useDialogOptions<D, DE> = {},
 ): useDialogReturn<D, R, DE> {
   const id = useId();
 


### PR DESCRIPTION
Adds an options argument to `useDialog` that accepts the following:
* `defaultData` - Sets some default data to be passed to the dialog. Setting this makes passing data to `.show()` optional, but passing data to `.show()` will still override default data
* `customKey` - Registers the dialog against this key instead of the default

### Progress
- [x] Implement `defaultData`
- [x] Implement `customKey`
- [x] Write tests
- [x] Update docs