### PR TITLE
Fix mounting behaviour

### DIFF
--- a/packages/react-dialog-async/package.json
+++ b/packages/react-dialog-async/package.json
@@ -2,7 +2,7 @@
   "name": "react-dialog-async",
   "description": "A promise-based way to show dialogs in React",
   "type": "module",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "sideEffects": false,
   "main": "index.js",
   "module": "index.esm.js",

--- a/packages/react-dialog-async/src/DialogProvider/DialogProvider.tsx
+++ b/packages/react-dialog-async/src/DialogProvider/DialogProvider.tsx
@@ -96,6 +96,10 @@ const DialogProvider = ({
   const show = useCallback(
     (id: string, data: unknown, unmountDelay?: number): Promise<unknown> => {
       return new Promise((resolve) => {
+        if (unmountDelayTimeoutRefs.current[id] !== undefined) {
+          clearTimeout(unmountDelayTimeoutRefs.current[id]);
+        }
+
         setDialogState((state) => ({
           ...state,
           [id]: {
@@ -167,6 +171,7 @@ const DialogProvider = ({
           key={id}
           open={open}
           data={data}
+          mounted={true} // Dialog is always mounted when it's being rendered
           handleClose={(value) => {
             resolve?.(value);
             hide(id);

--- a/packages/react-dialog-async/src/types.ts
+++ b/packages/react-dialog-async/src/types.ts
@@ -2,6 +2,7 @@ import type { ComponentType } from 'react';
 
 export interface AsyncDialogProps<Request = void, Response = undefined> {
   open: boolean;
+  mounted: boolean;
   handleClose: (data?: Response) => void;
   data: Request;
 }


### PR DESCRIPTION
* Expose a `mounted` prop to dialog components
* Cancel the unmount delay when a modal is quickly closed and reopened to prevent weird behaviour