### PR TITLE
Add <DialogOutlet/> component

### DIFF
--- a/docs/blog/2025-03-07-release-2-2-0.md
+++ b/docs/blog/2025-03-07-release-2-2-0.md
@@ -6,11 +6,11 @@ tags: [Release, Minor Release]
 
 Version 2.2.0 for React Dialog Async has been released 🎉
 
-This release introduces the `<DialogOutlet/>` component for solving issues with nested providers!
+This release introduces the `DialogOutlet` component for solving issues with nested providers!
 <!-- truncate -->
 
 ## What's new?
-* Previously, dialogs were rendered as direct children of the `<DialogProvider/>`. Now you can use a <DialogOutlet/> to instead render dialogs in a different place in the component tree  ([More details](/API/dialog-outlet))
+* Previously, dialogs were rendered as direct children of the `DialogProvider`. Now you can use a `DialogOutlet` to instead render dialogs in a different place in the component tree  ([More details](/API/dialog-outlet))
 * Internal performance optimisations
 ---
 

--- a/docs/blog/2025-03-07-release-2-2-0.md
+++ b/docs/blog/2025-03-07-release-2-2-0.md
@@ -10,7 +10,7 @@ This release introduces the `<DialogOutlet/>` component for solving issues with 
 <!-- truncate -->
 
 ## What's new?
-* Previously, dialogs were rendered as direct children of the `<DialogProvider/>`. Now you can use a <DialogOutlet/> to instead render dialogs in a different place in the component tree
+* Previously, dialogs were rendered as direct children of the `<DialogProvider/>`. Now you can use a <DialogOutlet/> to instead render dialogs in a different place in the component tree  ([More details](/API/dialog-outlet))
 * Internal performance optimisations
 ---
 

--- a/docs/blog/2025-03-07-release-2-2-0.md
+++ b/docs/blog/2025-03-07-release-2-2-0.md
@@ -1,0 +1,18 @@
+---
+title: V2.2.0 has been released
+description: Release notes for version 2.2.0
+tags: [Release, Minor Release]
+---
+
+Version 2.2.0 for React Dialog Async has been released 🎉
+
+This release introduces the `<DialogOutlet/>` component for solving issues with nested providers!
+<!-- truncate -->
+
+## What's new?
+* Previously, dialogs were rendered as direct children of the `<DialogProvider/>`. Now you can use a <DialogOutlet/> to instead render dialogs in a different place in the component tree
+* Internal performance optimisations
+---
+
+Feedback or ideas? We'd love to hear them! Open an issue over on [GitHub](https://github.com/a16n-dev/react-dialog-async/issues).
+

--- a/docs/docs/API/dialog-outlet.md
+++ b/docs/docs/API/dialog-outlet.md
@@ -1,0 +1,24 @@
+---
+sidebar_position: 2
+---
+
+# DialogOutlet
+```tsx
+import { DialogOutlet } from 'react-dialog-async';
+```
+Using a DialogOutlet allows you to render your dialogs in a different place in the component tree. This is most useful to ensure that dialogs are wrapped with all of the necessary context providers. If you don't provide a `DialogOutlet`, dialogs will be rendered as direct children of the `DialogProvider`.
+
+:::note
+Starting from version `2.2.0` we always recommend using a `DialogOutlet`. It is not compulsory to preserve backwards compatibility, but it is recommended for new projects.
+:::
+
+## Usage
+```tsx
+<DialogProvider>
+  {...}
+  <DialogOutlet/>
+</DialogProvider>
+```
+
+## Source
+[Source for `DialogOutlet` on GitHub](https://github.com/a16n-dev/react-dialog-async/tree/main/packages/react-dialog-async/src/DialogOutlet.tsx)

--- a/docs/docs/API/dialog-provider.md
+++ b/docs/docs/API/dialog-provider.md
@@ -23,4 +23,4 @@ Provides a react context for rendering dialogs. The dialogs themselves will also
 | `defaultUnmountDelayInMs` | `number?`         |               | Sets a default for the unmount delay for all dialogs |
 
 ## Source
-[Source for `DialogProvider` on GitHub](https://github.com/a16n-dev/react-dialog-async/blob/main/src/DialogProvider/DialogProvider.tsx)
+[Source for `DialogProvider` on GitHub](https://github.com/a16n-dev/react-dialog-async/tree/main/packages/react-dialog-async/src/DialogProvider/DialogProvider.tsx)

--- a/docs/docs/API/use-dialog.md
+++ b/docs/docs/API/use-dialog.md
@@ -43,4 +43,4 @@ The object returned by `useDialog` has the following properties:
 * `close` - Alias for `hide`
 
 ## Source
-[Source for `useDialog` on GitHub](https://github.com/a16n-dev/react-dialog-async/blob/main/src/useDialog.ts)
+[Source for `useDialog` on GitHub](https://github.com/a16n-dev/react-dialog-async/tree/main/packages/react-dialog-async/src/useDialog.ts)

--- a/docs/docs/basics/installation.mdx
+++ b/docs/docs/basics/installation.mdx
@@ -47,15 +47,16 @@ Install the package using your package manager of choice.
 
 ### Wrap your app with `DialogProvider`
 
-Add the provider `DialogProvider` to the root of your app
+Add the provider `DialogProvider` to the root of your app, and render a `DialogOutlet`
 
 ``` tsx
-import { DialogProvider } from 'react-dialog-async';
+import { DialogProvider, DialogOutlet } from 'react-dialog-async';
 
 export default function Layout() {
   return (
     <DialogProvider>
       <App />
+      <DialogOutlet/>
     </DialogProvider>
   );
 }

--- a/packages/react-dialog-async/package.json
+++ b/packages/react-dialog-async/package.json
@@ -2,7 +2,7 @@
   "name": "react-dialog-async",
   "description": "A promise-based way to show dialogs in React",
   "type": "module",
-  "version": "2.1.1",
+  "version": "2.2.0",
   "sideEffects": false,
   "main": "index.js",
   "module": "index.esm.js",

--- a/packages/react-dialog-async/src/DialogContext.tsx
+++ b/packages/react-dialog-async/src/DialogContext.tsx
@@ -2,19 +2,9 @@ import { createContext } from 'react';
 import { DialogComponent } from './types';
 
 export interface dialogContextState {
-  /**
-   * Register the dialog with the provider.
-   * @param id - uniquely identifies this instance of calling useDialog()
-   * @param key - identifies the dialog being used. This doesn't have to be unique.
-   * @param obj - the dialog component to be registered
-   */
-  register: (
-    id: string,
-    key: string,
-    obj: DialogComponent<any, any>,
-  ) => () => void;
   show: (
     dialogId: string,
+    dialog: DialogComponent<any, any>,
     data: unknown,
     unmountDelay?: number,
   ) => Promise<any>;
@@ -22,11 +12,6 @@ export interface dialogContextState {
   updateData: (dialogId: string, data: unknown) => void;
 }
 
-const DialogContext = createContext<dialogContextState>({
-  register: () => () => {},
-  show: async () => {},
-  hide: () => {},
-  updateData: () => {},
-});
+const DialogContext = createContext<dialogContextState | null>(null);
 
 export default DialogContext;

--- a/packages/react-dialog-async/src/DialogOutlet.tsx
+++ b/packages/react-dialog-async/src/DialogOutlet.tsx
@@ -1,0 +1,28 @@
+import React, { useContext, useEffect } from 'react';
+import DialogStateContext from './DialogStateContext';
+import useRenderDialogs from './useRenderDialogs';
+
+const DialogOutlet = () => {
+  const dialogState = useContext(DialogStateContext);
+
+  if (!dialogState) {
+    throw new Error(
+      'Dialog context not found. You likely forgot to wrap your app in a <DialogProvider/> (https://react-dialog-async.a16n.dev/installation)',
+    );
+  }
+
+  // This tells the provider not to render dialogs itself
+  useEffect(() => {
+    dialogState.setIsUsingOutlet(true);
+
+    return () => {
+      dialogState.setIsUsingOutlet(false);
+    };
+  }, []);
+
+  const dialogComponents = useRenderDialogs(dialogState.dialogs);
+
+  return <>{dialogComponents}</>;
+};
+
+export default DialogOutlet;

--- a/packages/react-dialog-async/src/DialogProvider/DialogProvider.test.tsx
+++ b/packages/react-dialog-async/src/DialogProvider/DialogProvider.test.tsx
@@ -3,8 +3,16 @@ import { expect, test } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import DialogProvider from './DialogProvider';
 import { useContext, useEffect, useId } from 'react';
-import DialogContext from '../DialogContext';
+import DialogContext, { dialogContextState } from '../DialogContext';
 import { AsyncDialogProps } from '../types';
+
+function ctxNotNull(ctx: dialogContextState | null): asserts ctx {
+  if (!ctx) {
+    throw new Error(
+      'Dialog context not found. You likely forgot to wrap your app in a <DialogProvider/> (https://react-dialog-async.a16n.dev/installation)',
+    );
+  }
+}
 
 const TestDialog = ({ open }: AsyncDialogProps) => {
   if (!open) return null;
@@ -24,35 +32,14 @@ test('renders children', () => {
   expect(screen.findByText('Hello world!')).toBeDefined();
 });
 
-test('calling register() does not mount the dialog', () => {
+test('calling  show() mounts the dialog in the DOM', () => {
   const InnerComponent = () => {
     const ctx = useContext(DialogContext);
+    ctxNotNull(ctx);
     const id = useId();
 
     useEffect(() => {
-      ctx.register(id, 'test', TestDialog);
-    }, [id]);
-
-    return null;
-  };
-  const result = render(
-    <DialogProvider>
-      <InnerComponent />
-    </DialogProvider>,
-  );
-
-  expect(result.asFragment()).toMatchSnapshot();
-});
-
-test('calling register() followed by show() mounts the dialog in the DOM', () => {
-  const InnerComponent = () => {
-    const ctx = useContext(DialogContext);
-    const id = useId();
-
-    useEffect(() => {
-      ctx.register(id, 'test', TestDialog);
-
-      ctx.show(id, {});
+      ctx.show(id, TestDialog, {});
     }, [id]);
 
     return null;
@@ -70,12 +57,11 @@ test('calling register() followed by show() mounts the dialog in the DOM', () =>
 test('calling register() followed by show() followed by hide() unmounts the dialog in the DOM', () => {
   const InnerComponent = () => {
     const ctx = useContext(DialogContext);
+    ctxNotNull(ctx);
     const id = useId();
 
     useEffect(() => {
-      ctx.register(id, 'test', TestDialog);
-
-      ctx.show(id, {});
+      ctx.show(id, TestDialog, {});
 
       ctx.hide(id);
     }, [id]);

--- a/packages/react-dialog-async/src/DialogProvider/__snapshots__/DialogProvider.test.tsx.snap
+++ b/packages/react-dialog-async/src/DialogProvider/__snapshots__/DialogProvider.test.tsx.snap
@@ -1,15 +1,13 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`calling register() does not mount the dialog 1`] = `<DocumentFragment />`;
-
-exports[`calling register() followed by show() followed by hide() unmounts the dialog in the DOM 1`] = `<DocumentFragment />`;
-
-exports[`calling register() followed by show() mounts the dialog in the DOM 1`] = `
+exports[`calling  show() mounts the dialog in the DOM 1`] = `
 <DocumentFragment>
   <div>
     Hello World!
   </div>
 </DocumentFragment>
 `;
+
+exports[`calling register() followed by show() followed by hide() unmounts the dialog in the DOM 1`] = `<DocumentFragment />`;
 
 exports[`renders without error 1`] = `<DocumentFragment />`;

--- a/packages/react-dialog-async/src/DialogStateContext.tsx
+++ b/packages/react-dialog-async/src/DialogStateContext.tsx
@@ -1,0 +1,22 @@
+import { createContext } from 'react';
+import { DialogComponent } from './types';
+
+export type dialogsStateData = Record<
+  string,
+  {
+    dialog: DialogComponent<any, any>;
+    data: unknown;
+    open: boolean;
+    resolve?: (value?: unknown) => void;
+    unmountDelay?: number;
+  }
+>;
+
+export type dialogStateContextState = {
+  setIsUsingOutlet: (value: boolean) => void;
+  dialogs: dialogsStateData;
+};
+
+const DialogStateContext = createContext<dialogStateContextState | null>(null);
+
+export default DialogStateContext;

--- a/packages/react-dialog-async/src/index.ts
+++ b/packages/react-dialog-async/src/index.ts
@@ -1,3 +1,4 @@
 export { default as DialogProvider } from './DialogProvider/DialogProvider';
+export { default as DialogOutlet } from './DialogOutlet';
 export { default as useDialog } from './useDialog';
 export { type AsyncDialogProps } from './types';

--- a/packages/react-dialog-async/src/useDialog.test.tsx
+++ b/packages/react-dialog-async/src/useDialog.test.tsx
@@ -95,8 +95,14 @@ test('default data is overridden when data is provided', () => {
 });
 
 test('unmount delay does not delay the promise being resolved', async () => {
-  const result = renderHook(() =>
-    useDialog(TestDialog, { unmountDelayInMs: Infinity }),
+  const result = renderHook(
+    () =>
+      useDialog(TestDialog, {
+        unmountDelayInMs: 100,
+      }),
+    {
+      wrapper: DialogProvider,
+    },
   );
 
   let value = false;

--- a/packages/react-dialog-async/src/useRenderDialogs.tsx
+++ b/packages/react-dialog-async/src/useRenderDialogs.tsx
@@ -1,0 +1,22 @@
+import { dialogsStateData } from './DialogStateContext';
+import React, { useMemo } from 'react';
+
+const useRenderDialogs = (state: dialogsStateData) => {
+  return useMemo(() => {
+    return Object.entries(state).map(
+      ([id, { dialog: Component, data, open, resolve }]) => {
+        return (
+          <Component
+            key={id}
+            open={open}
+            data={data}
+            mounted={true} // Dialog is always mounted when it's being rendered
+            handleClose={(value) => resolve?.(value)}
+          />
+        );
+      },
+    );
+  }, [state]);
+};
+
+export default useRenderDialogs;


### PR DESCRIPTION
Introduces <DialogOutlet/> to get around issues with provider nested issues.

Take this example when using both dialogs and toasts

### Before
Toasts can trigger dialogs, but dialogs cannot show toasts, as they sit outside the ToastProvider
```tsx
<DialogProvider>
  <ToastProvider>
    {...}
  </ToastProvider>
</DialogProvider>
```

### After
Dialogs can show toasts, and toasts can also trigger dialogs as they're within the provider
```tsx
<DialogProvider>
  <ToastProvider>
    {...}
    <DialogOutlet/>
  </ToastProvider>
</DialogProvider>
```