### PR TITLE
Bugfix: fix dialogOptions.customkey not being respected

### DIFF
--- a/packages/react-dialog-async/package.json
+++ b/packages/react-dialog-async/package.json
@@ -2,7 +2,7 @@
   "name": "react-dialog-async",
   "description": "A promise-based way to show dialogs in React",
   "type": "module",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "sideEffects": false,
   "main": "index.js",
   "module": "index.esm.js",

--- a/packages/react-dialog-async/src/useDialog.ts
+++ b/packages/react-dialog-async/src/useDialog.ts
@@ -1,6 +1,7 @@
 import { useCallback, useContext, useEffect, useId, useMemo } from 'react';
 import DialogContext from './DialogContext';
 import { DialogComponent, useDialogOptions, useDialogReturn } from './types';
+import { hashComponent } from './utils';
 
 function useDialog<D, R, DE extends D | undefined>(
   component: DialogComponent<D, R>,
@@ -8,10 +9,13 @@ function useDialog<D, R, DE extends D | undefined>(
 ): useDialogReturn<D, R, DE> {
   const internalId = useId();
 
-  const id = useMemo(
-    () => options?.customKey ?? internalId,
-    [internalId, options?.customKey],
-  );
+  const id = useMemo(() => {
+    if (options?.customKey !== undefined) {
+      return `${hashComponent(component)}-${options.customKey}`;
+    }
+
+    return internalId;
+  }, [internalId, component, options?.customKey]);
 
   const ctx = useContext(DialogContext);
 

--- a/packages/react-dialog-async/src/useDialog.ts
+++ b/packages/react-dialog-async/src/useDialog.ts
@@ -1,4 +1,4 @@
-import { useCallback, useContext, useEffect, useId, useMemo } from 'react';
+import { useCallback, useContext, useEffect, useMemo } from 'react';
 import DialogContext from './DialogContext';
 import { hashComponent } from './utils';
 import { DialogComponent, useDialogOptions, useDialogReturn } from './types';
@@ -7,9 +7,8 @@ function useDialog<D, R, DE extends D | undefined>(
   component: DialogComponent<D, R>,
   options?: useDialogOptions<D, DE>,
 ): useDialogReturn<D, R, DE> {
-  const id = useId();
-
-  const key = useMemo(
+  // use a custom key if it's provided, otherwise generate a key from the component used
+  const id = useMemo(
     () => options?.customKey ?? hashComponent(component),
     [component, options?.customKey],
   );
@@ -39,7 +38,7 @@ function useDialog<D, R, DE extends D | undefined>(
         options?.unmountDelayInMs,
       );
     },
-    [key, component, options?.defaultData, options?.unmountDelayInMs],
+    [id, component, options?.defaultData, options?.unmountDelayInMs],
   );
 
   const hide = () => {

--- a/packages/react-dialog-async/src/useDialog.ts
+++ b/packages/react-dialog-async/src/useDialog.ts
@@ -1,16 +1,16 @@
-import { useCallback, useContext, useEffect, useMemo } from 'react';
+import { useCallback, useContext, useEffect, useId, useMemo } from 'react';
 import DialogContext from './DialogContext';
-import { hashComponent } from './utils';
 import { DialogComponent, useDialogOptions, useDialogReturn } from './types';
 
 function useDialog<D, R, DE extends D | undefined>(
   component: DialogComponent<D, R>,
   options?: useDialogOptions<D, DE>,
 ): useDialogReturn<D, R, DE> {
-  // use a custom key if it's provided, otherwise generate a key from the component used
+  const internalId = useId();
+
   const id = useMemo(
-    () => options?.customKey ?? hashComponent(component),
-    [component, options?.customKey],
+    () => options?.customKey ?? internalId,
+    [internalId, options?.customKey],
   );
 
   const ctx = useContext(DialogContext);


### PR DESCRIPTION
`options.customKey `wasn't being respected, and instead would always just use the internally generated ID. This is considered a bug, as `customKey` should be used as the id when it's given.