### PR TITLE
Optimise state updates

### DIFF
--- a/packages/react-dialog-async/package.json
+++ b/packages/react-dialog-async/package.json
@@ -2,7 +2,7 @@
   "name": "react-dialog-async",
   "description": "A promise-based way to show dialogs in React",
   "type": "module",
-  "version": "2.3.1",
+  "version": "2.3.2",
   "sideEffects": false,
   "main": "index.js",
   "module": "index.esm.js",

--- a/packages/react-dialog-async/src/DialogProvider/DialogProvider.tsx
+++ b/packages/react-dialog-async/src/DialogProvider/DialogProvider.tsx
@@ -26,10 +26,11 @@ const DialogProvider = ({
    */
   const hide = useCallback(
     (id: string) => {
-      setDialogState((state) => {
-        if (!state[id]) return state;
+      // Do this check here to avoid unnecessary state updates
+      if (!dialogState[id]?.open) return;
 
-        if (!state[id].open) return state; // don't do anything if the dialog is already closed
+      setDialogState((state) => {
+        if (!state[id]?.open) return state; // don't do anything if the dialog is already closed
 
         state[id].resolve?.(undefined);
 


### PR DESCRIPTION
Unmounting `useDialog()` always results in a state update being dispatched, as `ctx.hide()` calls `setDialogState()` regardless of if the dialog is open or not.

As an optimisation, we can instead do this check before the state update.