### PR TITLE
Handle calling `show()` when dialog is already open

### DIFF
--- a/packages/react-dialog-async/package.json
+++ b/packages/react-dialog-async/package.json
@@ -2,7 +2,7 @@
   "name": "react-dialog-async",
   "description": "A promise-based way to show dialogs in React",
   "type": "module",
-  "version": "2.3.1",
+  "version": "2.3.2",
   "sideEffects": false,
   "main": "index.js",
   "module": "index.esm.js",

--- a/packages/react-dialog-async/src/DialogProvider/DialogProvider.tsx
+++ b/packages/react-dialog-async/src/DialogProvider/DialogProvider.tsx
@@ -65,6 +65,9 @@ const DialogProvider = ({
       data: unknown,
       unmountDelay?: number,
     ): Promise<unknown> => {
+      // if already open, do nothing
+      if (dialogState[id]?.open) return Promise.resolve();
+
       return new Promise((resolve) => {
         if (unmountDelayTimeoutRefs.current[id] !== undefined) {
           clearTimeout(unmountDelayTimeoutRefs.current[id]);


### PR DESCRIPTION
Calling `.show()` when a dialog is already open should do nothing, rather than update state and potentially remount the dialog