### PR TITLE
(2.4.0) `useDialogState` hook

### DIFF
--- a/packages/react-dialog-async/package.json
+++ b/packages/react-dialog-async/package.json
@@ -2,7 +2,7 @@
   "name": "react-dialog-async",
   "description": "A promise-based way to show dialogs in React",
   "type": "module",
-  "version": "2.3.2",
+  "version": "2.4.0",
   "sideEffects": false,
   "main": "index.js",
   "module": "index.esm.js",

--- a/packages/react-dialog-async/src/index.ts
+++ b/packages/react-dialog-async/src/index.ts
@@ -1,4 +1,5 @@
 export { default as DialogProvider } from './DialogProvider/DialogProvider';
 export { default as DialogOutlet } from './DialogOutlet';
 export { default as useDialog } from './useDialog';
+export { default as useDialogState } from './useDialogState';
 export { type AsyncDialogProps } from './types';

--- a/packages/react-dialog-async/src/types.ts
+++ b/packages/react-dialog-async/src/types.ts
@@ -69,3 +69,15 @@ export type useDialogOptions<D, DE extends D | undefined> = {
    */
   hideOnHookUnmount?: boolean;
 };
+
+export type useDialogStateReturn = {
+  /**
+   * Information about all currently open dialogs
+   */
+  openDialogs: Array<{
+    dialog: DialogComponent<any, any>;
+    id: string;
+    data: any;
+    open: boolean;
+  }>;
+};

--- a/packages/react-dialog-async/src/useDialogState.ts
+++ b/packages/react-dialog-async/src/useDialogState.ts
@@ -1,0 +1,26 @@
+import { useContext, useMemo } from 'react';
+import { useDialogStateReturn } from './types';
+import DialogStateContext from './DialogStateContext';
+
+function useDialogState(): useDialogStateReturn {
+  const dialogState = useContext(DialogStateContext);
+
+  if (!dialogState) {
+    throw new Error(
+      'Dialog context not found. You likely forgot to wrap your app in a <DialogProvider/> (https://react-dialog-async.a16n.dev/installation)',
+    );
+  }
+
+  return useMemo(() => {
+    return {
+      openDialogs: Object.entries(dialogState.dialogs).map(([k, v]) => ({
+        id: k,
+        dialog: v.dialog,
+        data: v.data,
+        open: v.open,
+      })),
+    };
+  }, [dialogState.dialogs]);
+}
+
+export default useDialogState;


### PR DESCRIPTION
The `useDialogState()` hook enables advanced use-cases by allowing applications to reason about the state of open dialogs, for example: only opening a dialog if no existing dialog is open.

Example usage:
```tsx
import { useDialogState } from 'react-dialog-async';

function MyComponent() {

  const { openDialogs } = useDialogState();

  return <p>{`Number of open dialogs: ${openDialogs.length}`}</p>
}
```
