### PR TITLE
Expose a `useDialogContext` hook to dialog components

### DIFF
--- a/packages/react-dialog-async/src/IndividualDialogContext.tsx
+++ b/packages/react-dialog-async/src/IndividualDialogContext.tsx
@@ -1,0 +1,25 @@
+import { createContext, useContext } from 'react';
+import { AsyncDialogProps } from './types';
+
+interface DialogContextValue<D = any, R = any> extends AsyncDialogProps<D, R> {
+  isInsideDialogContext: boolean;
+}
+
+const defaultDialogContextValue: DialogContextValue = {
+  open: false,
+  focused: false,
+  mounted: true,
+  handleClose: () => {},
+  data: undefined,
+  isInsideDialogContext: false,
+};
+
+const IndividualDialogContext = createContext<DialogContextValue>(
+  defaultDialogContextValue,
+);
+
+export const useDialogContext = <D = any, R = any>(): DialogContextValue<D, R> => {
+  return useContext(IndividualDialogContext);
+};
+
+export default IndividualDialogContext;

--- a/packages/react-dialog-async/src/index.ts
+++ b/packages/react-dialog-async/src/index.ts
@@ -1,4 +1,5 @@
 export { default as DialogProvider } from './DialogProvider/DialogProvider';
 export { default as DialogOutlet } from './DialogOutlet';
 export { default as useDialog } from './useDialog';
+export { useDialogContext } from './IndividualDialogContext';
 export { type AsyncDialogProps } from './types';

--- a/packages/react-dialog-async/src/useRenderDialogs.tsx
+++ b/packages/react-dialog-async/src/useRenderDialogs.tsx
@@ -1,5 +1,6 @@
 import { dialogsStateData } from './DialogStateContext';
 import React, { useMemo } from 'react';
+import IndividualDialogContext from './IndividualDialogContext';
 
 const useRenderDialogs = (state: dialogsStateData) => {
   return useMemo(() => {
@@ -13,15 +14,23 @@ const useRenderDialogs = (state: dialogsStateData) => {
     });
 
     return entries.map(([id, { dialog: Component, data, open, resolve }]) => {
+      const dialogProps = {
+        open,
+        data,
+        mounted: true as const, // Dialog is always mounted when it's being rendered
+        handleClose: (value: any) => resolve?.(value),
+        focused: id === lastOpenDialog, // Focus the last dialog in the list
+      };
+
+      const contextValue = {
+        ...dialogProps,
+        isInsideDialogContext: true,
+      };
+
       return (
-        <Component
-          key={id}
-          open={open}
-          data={data}
-          mounted={true} // Dialog is always mounted when it's being rendered
-          handleClose={(value) => resolve?.(value)}
-          focused={id === lastOpenDialog} // Focus the last dialog in the list
-        />
+        <IndividualDialogContext.Provider key={id} value={contextValue}>
+          <Component {...dialogProps} />
+        </IndividualDialogContext.Provider>
       );
     });
   }, [state]);


### PR DESCRIPTION
Currently the only way to access information about the dialog state from within the dialog is via props. These props have to be drilled down into whatever dialog components you're using, something like:

```tsx
function MyDialog({ open, data, handleClose }: AsyncDialogProps) {
  return (
    <Dialog open={open} onClose={() => handleClose()}>
      <DialogHeader open={open} onClose={() => handleClose()} />
      {...}
    </Dialog>
  );
}
```

This PR introduces a dialog context that components can use to access props, so a custom `DialogHeader` component could be rewritten to something like:

```tsx
function DialogHeader() {
  const { open, handleClose } = useDialogContext();
  
  return (
    <div>
      {...}
      <button onClick={() => handleClose()} >X</button>
    </div>
  )
}