### PR TITLE
API for `useDialogLazy()` 

### DIFF
--- a/packages/react-dialog-async/src/DialogContext.tsx
+++ b/packages/react-dialog-async/src/DialogContext.tsx
@@ -11,6 +11,7 @@ export interface dialogContextState {
   ) => Promise<any>;
   hide: (dialogId: string) => void;
   updateData: (dialogId: string, data: unknown) => void;
+  lazyLoaderFn?: (loaderFn: () => Promise<void>) => Promise<void>;
 }
 
 const DialogContext = createContext<dialogContextState | null>(null);

--- a/packages/react-dialog-async/src/DialogProvider/DialogProvider.tsx
+++ b/packages/react-dialog-async/src/DialogProvider/DialogProvider.tsx
@@ -10,10 +10,17 @@ interface DialogProviderProps extends PropsWithChildren {
    * The default delay in milliseconds to wait before unmounting a dialog after it's closed.
    */
   defaultUnmountDelayInMs?: number;
+  /**
+   * If provided, this function will be called when useDialogLazy is mounted.
+   * This lets you call the preload function at some point before the lazy component is required
+   * Consult the docs for some sensible functions to provide here for different environments
+   */
+  lazyLoaderFn?: (preload: () => Promise<void>) => Promise<void>;
 }
 
 const DialogProvider = ({
   defaultUnmountDelayInMs,
+  lazyLoaderFn,
   children,
 }: DialogProviderProps) => {
   // This ref tracks timers for unmount dialogs after they're closed
@@ -127,6 +134,7 @@ const DialogProvider = ({
       show,
       hide,
       updateData,
+      lazyLoaderFn,
     }),
     [show, hide, updateData],
   );

--- a/packages/react-dialog-async/src/useDialogLazy.tsx
+++ b/packages/react-dialog-async/src/useDialogLazy.tsx
@@ -1,0 +1,122 @@
+import {
+  useCallback,
+  useContext,
+  useEffect,
+  useId,
+  useMemo,
+  useRef,
+} from 'react';
+import { DialogComponent, useDialogOptions, useDialogReturn } from './types';
+import DialogContext from './DialogContext';
+
+export type useDialogLazyReturn<
+  D,
+  R,
+  DE extends D | undefined,
+> = useDialogReturn<D, R, DE> & {
+  /**
+   * Call this method to preload the dialog ahead of time. If you don't call this method,
+   * the dialog component will be loaded the first time dialog.open() is called.
+   *
+   * Example usage:
+   * ```tsx
+   * const myDialog = useDialogLazy(() => import('./MyDialog'));
+   *
+   * return (
+   *   <button
+   *     onMouseOver={() => myDialog.preload()}
+   *     onClick={() => myDialog.open()}
+   *   >
+   *     Open Dialog
+   *   </button>
+   * );
+   * ```
+   */
+  preload: () => Promise<void>;
+};
+
+function useDialogLazy<D, R, DE extends D | undefined>(
+  componentLoader: () => Promise<DialogComponent<D, R>>,
+  options?: useDialogOptions<D, DE>,
+): useDialogLazyReturn<D, R, DE> {
+  const internalId = useId();
+  let idCount = useRef(0);
+  const componentRef = useRef<DialogComponent<D, R> | null>(null);
+
+  const id = useMemo(() => {
+    if (options?.customKey !== undefined) {
+      return options.customKey;
+    }
+
+    return internalId;
+  }, [internalId, options?.customKey]);
+
+  const ctx = useContext(DialogContext);
+
+  if (!ctx) {
+    throw new Error(
+      'Dialog context not found. You likely forgot to wrap your app in a <DialogProvider/> (https://react-dialog-async.a16n.dev/installation)',
+    );
+  }
+
+  useEffect(() => {
+    if (ctx.lazyLoaderFn) {
+      // Call the lazy loader function with a callback to load the component
+      void ctx.lazyLoaderFn(async () => {
+        if (!componentRef.current) {
+          componentRef.current = await componentLoader();
+        }
+      });
+    }
+  }, []);
+
+  useEffect(() => {
+    return () => {
+      if (options?.hideOnHookUnmount !== false) {
+        ctx.hide(id);
+      }
+    };
+  }, [id, options?.hideOnHookUnmount]);
+
+  const show = useCallback(
+    async (data?: D): Promise<R | undefined> => {
+      if (!componentRef.current) {
+        componentRef.current = await componentLoader();
+      }
+
+      return ctx.show(
+        id,
+        idCount.current++,
+        componentRef.current,
+        data ?? options?.defaultData,
+        options?.unmountDelayInMs,
+      );
+    },
+    [id, options?.defaultData, options?.unmountDelayInMs],
+  );
+
+  const hide = () => {
+    return ctx.hide(id);
+  };
+
+  const updateData = (data: D) => {
+    return ctx.updateData(id, data);
+  };
+
+  const preload = async () => {
+    if (!componentRef.current) {
+      componentRef.current = await componentLoader();
+    }
+  };
+
+  return {
+    show,
+    hide,
+    preload,
+    updateData,
+    open: show,
+    close: hide,
+  };
+}
+
+export default useDialogLazy;


### PR DESCRIPTION
## Why
Because dialogs are often only triggered by user interaction on a page, they do not need to be loaded immediately and are therefore good candidates for lazy loading via dynamic imports.

The high-level idea would be to allow `useDialog` to accept a dynamic import instead of a component. This import would then be resolved at some point after the initial render, but preferably before it's needed to be shown to the user:

```tsx
const myDialog = useDialog(() => import('./MyDialog')); // Dynamic import here that returns a promise

function handleClick() {
  await myDialog.open(); // Ideally the component is loaded *before* this is called
}
```

## Suggested API
This is probably best served by a new hook, rather than trying to shim it into the existing `useDialog()`:
```tsx
import { useDialogLazy } from 'react-dialog-async';

// With a default export
const myDialog = useDialogLazy(() => import('./MyDialog'));

// This can also be done for named exports, but it's slightly less nice
const myDialog = useDialogLazy(() => (await import('./MyDialog')).MyDialog);
```
The `useDialogLazy()` can then also expose a new option to preload the dialog:
```tsx
const myDialog = useDialogLazy(() => import('./MyDialog'));

return (
   <button
     onMouseOver={() => myDialog.preload()}
     onClick={() => myDialog.open()}
   >
    Open Dialog
   </button>
 );
</button>
```

Additionally, it would be preferable to have a global option to tell the library to preload earlier if possible, by taking advantage of `requestIdleCallback` (or similar) on web. This is probably best set as a prop on the provider:

```tsx
<DialogProvider onRegisterLazyDialog={(preload) => {
    requestIdleCallback(() => preload(), 1000);
  }}
>
  ...
</DialogProvider>
```
